### PR TITLE
fix: Spelling

### DIFF
--- a/Exposure Variance Calculator/Printer.h
+++ b/Exposure Variance Calculator/Printer.h
@@ -62,11 +62,11 @@ void printEquation(const float shutterSpeed, const float apeature, const int iso
 }
 
 void printEquation() {
-	cout	<< "Equation:	log2[( apeature^2 * 100 ) / ( 1 / shutterSpeed * iso )]" << endl
+	cout	<< "Equation:	log2[( aperture^2 * 100 ) / ( 1 / shutterSpeed * iso )]" << endl
 			<< endl;
 }
 
-//Reccomended you use `CalculateExposureVariance(shutterSpeed, aperture, iso)` if performing this in main.
+//Recommended you use `CalculateExposureVariance(shutterSpeed, aperture, iso)` if performing this in main.
 void printAnswer(const float EVoutput) {
 	cout	<< "Exposure Variance Equals:	" << EVoutput << endl	//also print equivalent scenes for this EV.
 			<< endl;


### PR DESCRIPTION
## Summary

Corrects two spelling mistakes in the printer output/comment text.

## Changes

- Changes `apeature` to `aperture` in the displayed equation string.
- Changes `Reccomended` to `Recommended` in a nearby comment.

## Testing

- Ran `c++ -std=c++17 -fsyntax-only "Exposure Variance Calculator/Exposure Variance Calculator.cpp"` successfully.

Fixes BEG5210/Exposure-Value-Calculator#6